### PR TITLE
Apply accumulated uniform scaling to text size

### DIFF
--- a/src/Diagrams/Backend/Canvas.hs
+++ b/src/Diagrams/Backend/Canvas.hs
@@ -362,8 +362,10 @@ instance Renderable Text Canvas where
     tx      <- fromMaybe (SC (SomeColor (black :: Colour Double)))
                <$> getStyleAttrib getFillTexture
     o       <- fromMaybe 1 <$> getStyleAttrib getOpacity
-    let fnt = showFontJS fw slant sz tf
-        tr  = if isLocal then tt else tn
+    let fSize = if isLocal
+                        then avgScale tt * size
+                        else size
+        fnt = showFontJS fw slant fSize tf
         vAlign = case al of
                    BaselineText -> T.pack "alphabetic"
                    BoxAlignedText _ h -> case h of
@@ -381,7 +383,7 @@ instance Renderable Text Canvas where
     liftC $ BC.textAlign hAlign
     liftC $ BC.font fnt
     fillTexture tx o
-    canvasTransform (tr <> reflectionY)
+    canvasTransform (tn <> reflectionY)
     liftC $ BC.fillText (T.pack str, 0, 0)
     restore
 


### PR DESCRIPTION
This is the same change that has helped in Cairo and elsewhere.  Take the uniform scaling part of `tt`, and multiply the text size that the backend uses to calculate font metrics.  Rendering of the example in #1 is greatly improved in Firefox and Chromium.  It's not perfect, but it's at least reasonable -- in a real diagram I'd make the square 1.1 or 1.2 and call it a day.
