### PR TITLE
Bump text upper version bounds

### DIFF
--- a/diagrams-canvas.cabal
+++ b/diagrams-canvas.cabal
@@ -33,7 +33,7 @@ Library
                        blank-canvas >= 0.4 && < 0.5,
                        lens >= 4.0 && < 4.5,
                        containers >= 0.3 && < 0.6,
-                       text >= 1.0 && < 1.2,
+                       text >= 1.0 && < 1.3,
                        data-default-class >= 0.0.1 && < 0.1,
                        statestack >= 0.2 && <0.3,
                        optparse-applicative >= 0.10 && < 0.11


### PR DESCRIPTION
Allow `diagrams-canvas` to use `text-1.2.0.0`.
