### PR TITLE
Bump NumInstances upper version bounds

### DIFF
--- a/diagrams-canvas.cabal
+++ b/diagrams-canvas.cabal
@@ -26,7 +26,7 @@ Library
   Build-depends:       base >= 4.6 && < 4.8,
                        mtl >= 2.0 && < 3.0,
                        vector-space >= 0.7 && < 0.9,
-                       NumInstances >= 1.0 && < 1.4,
+                       NumInstances >= 1.0 && < 1.5,
                        diagrams-core >= 1.2 && < 1.3,
                        diagrams-lib >= 1.2 && < 1.3,
                        cmdargs >= 0.6 && < 0.11,


### PR DESCRIPTION
Accommodate the latest version of `NumInstances`. As far as I can tell, the only major change in 1.4 is the addition of instances for tuples.
