### PR TITLE
Bump lens upper version bounds

### DIFF
--- a/diagrams-canvas.cabal
+++ b/diagrams-canvas.cabal
@@ -30,7 +30,7 @@ Library
                        diagrams-lib >= 1.2 && < 1.3,
                        cmdargs >= 0.6 && < 0.11,
                        blank-canvas >= 0.5 && < 0.6,
-                       lens >= 4.0 && < 4.5,
+                       lens >= 4.0 && < 4.6,
                        containers >= 0.3 && < 0.6,
                        text >= 1.0 && < 1.3,
                        data-default-class >= 0.0.1 && < 0.1,


### PR DESCRIPTION
Allow `diagrams-canvas` to use the latest version of `lens` (4.5).
