### PR TITLE
Allow newer base, lens, containers

### DIFF
--- a/diagrams-canvas.cabal
+++ b/diagrams-canvas.cabal
@@ -24,15 +24,15 @@ Library
   Exposed-modules:     Diagrams.Backend.Canvas
                        Diagrams.Backend.Canvas.CmdLine
   Hs-source-dirs:      src
-  Build-depends:       base >= 4.13 && < 4.20,
+  Build-depends:       base >= 4.13 && < 4.21,
                        mtl >= 2.0 && < 2.4,
                        NumInstances >= 1.0 && < 1.5,
                        diagrams-core >= 1.3 && < 1.6,
                        diagrams-lib >= 1.3 && < 1.5,
                        cmdargs >= 0.6 && < 0.11,
                        blank-canvas >= 0.5 && < 0.8,
-                       lens >= 4.0 && < 5.3,
-                       containers >= 0.3 && < 0.7,
+                       lens >= 4.0 && < 5.4,
+                       containers >= 0.3 && < 0.8,
                        text >= 1.0 && < 2.2,
                        data-default-class >= 0.0.1 && < 0.2,
                        statestack >= 0.2 && <0.4,


### PR DESCRIPTION
Tested using

    cabal build -c 'lens>=5.3' -c 'containers>=0.7' -w ghc-9.10.1

Closes #21.

Addresses

* https://github.com/commercialhaskell/stackage/issues/7408
